### PR TITLE
Fix issue when ActiveRecord is imported without rails

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', '3.1', '3.2', '3.3', '3.4', '4.0' ]
+        ruby: [ '3.2', '3.3', '3.4', '4.0' ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Install gems
         run: |
           gem install bundler
-          bundle install --with development test
+          bundle config set with 'development test'
+          bundle install
       - name: Runs tests
         run: |
           bundle exec rspec -f j -o rspec_results.json -f p

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,7 +4,6 @@ on:
   - workflow_dispatch
 env:
   RACK_ENV: test
-  ImageOS: ubuntu20
 jobs:
   test:
     name: Run test
@@ -14,21 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '3.0', '3.1', '3.2', '3.3', '3.4', '4.0' ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Cache gems
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-${{ matrix.ruby }}
       - name: Install gems
         run: |
           gem install bundler
@@ -38,12 +30,8 @@ jobs:
           bundle exec rspec -f j -o rspec_results.json -f p
       - name: RSpec Report
         if: always()
-        uses: SonicGarden/rspec-report-action@v1
+        uses: SonicGarden/rspec-report-action@v6
+        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           json-path: rspec_results.json
-      - name: Simplecov Report
-        uses: aki77/simplecov-report-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          failedThreshold: 80

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install gems
         run: |
           gem install bundler
-          bundle install --with development test --deployment --jobs 16
+          bundle install --with development test
       - name: Runs tests
         run: |
           bundle exec rspec -f j -o rspec_results.json -f p

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,12 @@
-  source 'https://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in gb_dispatch.gemspec
 gemspec
 
 gem 'concurrent-ruby-ext'
+gem 'rake', '>= 13.2'
 
 group :test do
-  gem 'rspec'
+  gem 'rspec', '~> 3.10'
   gem 'simplecov', :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,11 +37,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (>= 2.2)
   concurrent-ruby-ext
   gb_dispatch!
   rake (>= 13.2)
-  rspec (~> 3.10, >= 0)
+  rspec (~> 3.10)
   simplecov
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    gb_dispatch (0.1.2)
-      concurrent-ruby (~> 1.0)
+    gb_dispatch (0.1.3)
+      concurrent-ruby (>= 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.1.9)
-    concurrent-ruby-ext (1.1.9)
-      concurrent-ruby (= 1.1.9)
+    concurrent-ruby (1.3.6)
+    concurrent-ruby-ext (1.3.6)
+      concurrent-ruby (= 1.3.6)
     diff-lcs (1.4.4)
     docile (1.4.0)
-    rake (13.0.6)
+    rake (13.3.1)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -37,12 +37,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.2)
+  bundler (>= 2.2)
   concurrent-ruby-ext
   gb_dispatch!
-  rake (~> 13.0)
-  rspec
+  rake (>= 13.2)
+  rspec (~> 3.10, >= 0)
   simplecov
 
 BUNDLED WITH
-   2.2.30
+  4.0.3

--- a/gb_dispatch.gemspec
+++ b/gb_dispatch.gemspec
@@ -19,8 +19,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'concurrent-ruby', '>= 1.0'
-  spec.add_development_dependency 'bundler', '>= 2.2'
-  spec.add_development_dependency 'rake', '>= 13.2'
-  spec.add_development_dependency 'rspec', '~> 3.10'
-  spec.add_development_dependency 'simplecov'
 end

--- a/gb_dispatch.gemspec
+++ b/gb_dispatch.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_development_dependency 'bundler', '~> 2.2'
-  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_runtime_dependency 'concurrent-ruby', '>= 1.0'
+  spec.add_development_dependency 'bundler', '>= 2.2'
+  spec.add_development_dependency 'rake', '>= 13.2'
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'simplecov'
 end

--- a/lib/gb_dispatch/queue.rb
+++ b/lib/gb_dispatch/queue.rb
@@ -39,6 +39,17 @@ module GBDispatch
             end
           end
         end
+      elsif defined?(ActiveRecord::Base)
+        require 'gb_dispatch/active_record_patch'
+        thread_block = ->() do
+          begin
+            ActiveRecord::Base.connection_pool.force_new_connection do
+              block ? block.call : yield
+            end
+          ensure
+            ActiveRecord::Base.clear_active_connections!
+          end
+        end
       else
         thread_block = block ? block : ->() { yield }
       end

--- a/lib/gb_dispatch/queue.rb
+++ b/lib/gb_dispatch/queue.rb
@@ -20,38 +20,12 @@ module GBDispatch
     # @return [Object, Exception] returns value of executed block or exception if block execution failed.
     def perform_now(block=nil)
       Thread.current[:name] ||= name
-      if defined?(Rails) && defined?(ActiveRecord::Base)
-        require 'gb_dispatch/active_record_patch'
-        thread_block = ->() do
-          if Rails::VERSION::MAJOR < 5
-            begin
-              ActiveRecord::Base.connection_pool.force_new_connection do
-                block ? block.call : yield
-              end
-            ensure
-              ActiveRecord::Base.clear_active_connections!
-            end
-          else
-            Rails.application.executor.wrap do
-              ActiveRecord::Base.connection_pool.force_new_connection do
-                block ? block.call : yield
-              end
-            end
+      thread_block = ->() do
+        with_rails_executor do
+          with_connection_pool do
+            block ? block.call : yield
           end
         end
-      elsif defined?(ActiveRecord::Base)
-        require 'gb_dispatch/active_record_patch'
-        thread_block = ->() do
-          begin
-            ActiveRecord::Base.connection_pool.force_new_connection do
-              block ? block.call : yield
-            end
-          ensure
-            ActiveRecord::Base.clear_active_connections!
-          end
-        end
-      else
-        thread_block = block ? block : ->() { yield }
       end
       begin
         Runner.execute thread_block, name: name
@@ -67,8 +41,9 @@ module GBDispatch
     # @return [Concurrent::ScheduledTask]
     def perform_after(time, block=nil)
       task = Concurrent::ScheduledTask.new(time) do
-        block = ->(){ yield } unless block
-        self.async.perform_now block
+        self.async.perform_now do
+          block ? block.call : yield
+        end
       end
       task.execute
       task
@@ -76,6 +51,29 @@ module GBDispatch
 
     def to_s
       self.name.to_s
+    end
+
+    private
+
+    def with_connection_pool
+      return yield unless defined?(ActiveRecord::Base)
+
+      require 'gb_dispatch/active_record_patch'
+      begin
+      ActiveRecord::Base.connection_pool.with_connection do
+        yield
+      end
+      ensure
+        ActiveRecord::Base.clear_active_connections!
+      end
+    end
+
+    def with_rails_executor
+      return yield unless defined?(Rails) && Rails::VERSION::MAJOR >= 5
+
+      Rails.application.executor.wrap do
+        yield
+      end
     end
   end
 end

--- a/lib/gb_dispatch/version.rb
+++ b/lib/gb_dispatch/version.rb
@@ -1,3 +1,3 @@
 module GBDispatch
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/spec/queue_spec.rb
+++ b/spec/queue_spec.rb
@@ -147,4 +147,73 @@ describe GBDispatch::Queue do
       expect(a).to eq :bar
     end
   end
+
+  context 'activerecord without rails' do
+    before(:each) do
+      module ActiveRecord
+        class Base
+          class DummyConnectionPool
+            def with_connection
+              yield
+            end
+
+            def force_new_connection
+              with_connection do
+                yield
+              end
+            end
+          end
+
+          def self.connection_pool
+            @pool ||= DummyConnectionPool.new
+          end
+
+          def self.clear_active_connections!
+            true
+          end
+        end
+      end
+    end
+
+    after(:each) do
+      begin
+        Kernel.send :remove_const, 'ActiveRecord'
+      rescue
+        nil
+      end
+      begin
+        Object.send :remove_const, 'ActiveRecord'
+      rescue
+        nil
+      end
+    end
+
+    it 'should wrap execution with connection pool when activerecord is present without rails' do
+      a = :foo
+      queue = GBDispatch::Queue.new(:test)
+      expect(ActiveRecord::Base.connection_pool).to receive(:with_connection).and_call_original
+      expect(ActiveRecord::Base).to receive(:clear_active_connections!)
+      queue.await.perform_now do
+        a = :bar
+      end
+      expect(a).to eq :bar
+    end
+
+    it 'should execute lambda and wrap with connection pool' do
+      a = :foo
+      queue = GBDispatch::Queue.new(:test)
+      expect(ActiveRecord::Base.connection_pool).to receive(:with_connection).and_call_original
+      expect(ActiveRecord::Base).to receive(:clear_active_connections!)
+      queue.await.perform_now ->() { a = :bar }
+      expect(a).to eq :bar
+    end
+
+    it 'should return exception object on failure without rails' do
+      queue = GBDispatch::Queue.new(:test)
+      a = queue.perform_now ->() do
+        raise StandardError.new 'Test error'
+      end
+      expect(a).to be_kind_of StandardError
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'simplecov'
-require 'ostruct'
 SimpleCov.start do
   add_filter '/spec/'
 end


### PR DESCRIPTION
Execution block wasn't wrapped in connection pool when ActiveRecord was used without Rails