### PR TITLE
Make force_new_connection safe under Rails 7.2+ pinned pools

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gb_dispatch (0.1.3)
+    gb_dispatch (0.1.5)
       concurrent-ruby (>= 1.0)
 
 GEM

--- a/lib/gb_dispatch/active_record_patch.rb
+++ b/lib/gb_dispatch/active_record_patch.rb
@@ -2,14 +2,48 @@ if defined?(ActiveRecord)
   module ActiveRecord
     module ConnectionAdapters
       class ConnectionPool
+        # Run the given block with a connection that is safe to use from a
+        # background worker thread even when the caller thread has pinned the
+        # pool (`use_transactional_fixtures`).
+        #
+        # Rails' pool changed shape across versions, so this monkey-patch
+        # has three branches:
+        #
+        # * Rails 7.2+ with `@pinned_connection` set. The pool forces every
+        #   caller onto one shared connection during a pinned test. We can't
+        #   hand out a different one without breaking the test's transaction
+        #   visibility, so instead we share the pinned connection while
+        #   serializing access via its per-connection `Mutex` (`.lock`). This
+        #   is what prevents the `PG::UnableToSend: another command is already
+        #   in progress` / `message type 0x5a arrived from server while idle`
+        #   wire-protocol corruption when the worker thread interleaves with
+        #   the test thread.
+        # * Rails 7.1 with `@lock_thread` defined. `with_connection` hands back
+        #   the caller thread's thread-cached connection; nilling `@lock_thread`
+        #   temporarily lets us get a fresh one from the pool instead.
+        # * Anything else (production without pinning, older AR, non-Rails
+        #   embedding). `with_connection` already yields a thread-local
+        #   connection from the pool; we just delegate.
         def force_new_connection
-          old_lock = @lock_thread
-          @lock_thread = nil
-          with_connection do |conn|
-            yield conn
+          if instance_variable_defined?(:@pinned_connection) && @pinned_connection
+            @pinned_connection.lock.synchronize do
+              yield @pinned_connection
+            end
+          elsif instance_variable_defined?(:@lock_thread)
+            old_lock = @lock_thread
+            @lock_thread = nil
+            begin
+              with_connection do |conn|
+                yield conn
+              end
+            ensure
+              @lock_thread = old_lock
+            end
+          else
+            with_connection do |conn|
+              yield conn
+            end
           end
-        ensure
-          @lock_thread = old_lock
         end
       end
     end

--- a/lib/gb_dispatch/queue.rb
+++ b/lib/gb_dispatch/queue.rb
@@ -59,7 +59,15 @@ module GBDispatch
       return yield unless defined?(ActiveRecord::Base)
 
       require 'gb_dispatch/active_record_patch'
-      ActiveRecord::Base.connection_pool.with_connection do
+      # `force_new_connection` (monkey-patch in active_record_patch.rb) temporarily
+      # nils `@lock_thread` on the pool so a background worker thread gets its
+      # own connection instead of inheriting the caller thread's cached one.
+      # Plain `with_connection` respects the lock, which under Rails
+      # `use_transactional_fixtures` hands the worker the test thread's
+      # in-transaction connection via `@thread_cached_conns`; both threads then
+      # race on the same Postgres socket and produce
+      # `PG::UnableToSend: another command is already in progress`.
+      ActiveRecord::Base.connection_pool.force_new_connection do
         yield
       end
     end

--- a/lib/gb_dispatch/queue.rb
+++ b/lib/gb_dispatch/queue.rb
@@ -59,14 +59,17 @@ module GBDispatch
       return yield unless defined?(ActiveRecord::Base)
 
       require 'gb_dispatch/active_record_patch'
-      # `force_new_connection` (monkey-patch in active_record_patch.rb) temporarily
-      # nils `@lock_thread` on the pool so a background worker thread gets its
-      # own connection instead of inheriting the caller thread's cached one.
-      # Plain `with_connection` respects the lock, which under Rails
-      # `use_transactional_fixtures` hands the worker the test thread's
-      # in-transaction connection via `@thread_cached_conns`; both threads then
-      # race on the same Postgres socket and produce
-      # `PG::UnableToSend: another command is already in progress`.
+      # `force_new_connection` is a monkey-patch in active_record_patch.rb
+      # that keeps background-thread connection handling safe across Rails
+      # versions:
+      #
+      # * On Rails 7.2+ with `@pinned_connection` (`use_transactional_fixtures`),
+      #   it serializes access to the pinned connection via its per-connection
+      #   mutex so worker and caller threads can't race on the same pg socket.
+      # * On Rails 7.1 with `@lock_thread`, it nils the lock so the worker
+      #   gets a fresh connection instead of inheriting the caller's cached one.
+      # * Otherwise (production, older AR, non-Rails), it delegates to
+      #   plain `with_connection`.
       ActiveRecord::Base.connection_pool.force_new_connection do
         yield
       end

--- a/lib/gb_dispatch/version.rb
+++ b/lib/gb_dispatch/version.rb
@@ -1,3 +1,3 @@
 module GBDispatch
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/spec/queue_spec.rb
+++ b/spec/queue_spec.rb
@@ -139,7 +139,7 @@ describe GBDispatch::Queue do
     it 'should wrap execution with connection pool' do
       a = :foo
       queue = GBDispatch::Queue.new(:test)
-      expect(ActiveRecord::Base.connection_pool).to receive(:with_connection).and_call_original
+      expect(ActiveRecord::Base.connection_pool).to receive(:force_new_connection).and_call_original
       queue.await.perform_now do
         a = :bar
       end
@@ -190,7 +190,7 @@ describe GBDispatch::Queue do
     it 'should wrap execution with connection pool when activerecord is present without rails' do
       a = :foo
       queue = GBDispatch::Queue.new(:test)
-      expect(ActiveRecord::Base.connection_pool).to receive(:with_connection).and_call_original
+      expect(ActiveRecord::Base.connection_pool).to receive(:force_new_connection).and_call_original
       queue.await.perform_now do
         a = :bar
       end
@@ -200,7 +200,7 @@ describe GBDispatch::Queue do
     it 'should execute lambda and wrap with connection pool' do
       a = :foo
       queue = GBDispatch::Queue.new(:test)
-      expect(ActiveRecord::Base.connection_pool).to receive(:with_connection).and_call_original
+      expect(ActiveRecord::Base.connection_pool).to receive(:force_new_connection).and_call_original
       queue.await.perform_now ->() { a = :bar }
       expect(a).to eq :bar
     end


### PR DESCRIPTION
## Summary

Rewrite `ActiveRecord::ConnectionAdapters::ConnectionPool#force_new_connection` (our monkey-patch) so it's correct across Rails 7.1, 7.2, and non-Rails consumers.

## Why

The 0.1.2 monkey-patch was written against Rails 7.1's `@lock_thread` + `@thread_cached_conns` pool shape. In 7.2, AR rebuilt the pool on `@pinned_connection` + `LeaseRegistry`, so writing `@lock_thread = nil` targets an ivar that's never read. That isn't immediately catastrophic — but dropping the monkey-patch entirely (as 0.1.3 / 0.1.4 did) and calling `with_connection` directly means the worker thread inherits the pinned connection with no serialization.

Under a pinned pool (`use_transactional_fixtures`), both the caller and worker threads then share the pinned connection and can interleave queries on the same pg socket. Symptom: `PG::UnableToSend: another command is already in progress` or `message type 0x5a arrived from server while idle`. We reproduced multi-minute hangs on three parallel_tests groups during genieplanner-server's Rails 7.2 upgrade.

## Fix

`force_new_connection` now branches on the pool shape:

| Condition | Behavior |
|---|---|
| `@pinned_connection` set (Rails 7.2+ transactional tests) | Share the pinned connection; run the block inside `@pinned_connection.lock.synchronize` so caller and worker never interleave on the socket. |
| `@lock_thread` defined (Rails 7.1) | Stash `@lock_thread`, nil it, delegate to `with_connection` (same behaviour as 0.1.2). |
| Neither (production, older AR, non-Rails embedding) | Delegate straight to `with_connection` — the pool already yields a thread-local connection. |

`queue.rb` keeps calling `force_new_connection`; only the patch body changed. The comments in both files were rewritten to describe the new three-branch logic.

We share-and-serialize rather than hand out a fresh connection under pinning because handing out a fresh connection would break test-transaction visibility — the worker wouldn't see the test's uncommitted writes, and any callback that consults DB state (e.g. `Hooks::Attachment#remove_project_authorisation`) would silently read stale data.

## Test plan

- [x] Verified against genieplanner-server on Rails 7.2.3 via a `path: '../gb-dispatch'` Gemfile override
- [x] `gmake spec_local` (parallel_tests 8-way, PG 17): **5320 examples, 0 failures, 37 pending, 6:33** — vs 44-minute hangs on three groups with gb_dispatch 0.1.4 unpatched
- [ ] Existing gb-dispatch unit tests still green (needs CI)
- [ ] Confirm behaviour under Rails 7.1 hasn't regressed (needs CI with the appraisal gemfile)

## Release

This bumps to 0.1.5 and should unblock unpinning `gb_dispatch` in consumer apps that are on Rails 7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)